### PR TITLE
updated olca-schema

### DIFF
--- a/electricitylci/olca_jsonld_writer.py
+++ b/electricitylci/olca_jsonld_writer.py
@@ -20,14 +20,14 @@ def write(processes: dict, file_path: str):
             process = olca.Process()
             process.name = _val(d, 'name')
             category_path = _val(d, 'category', default='')
+            location_code = _val(d, 'location', 'name', default='')
             process.id = _uid(olca.ModelType.PROCESS,
-                              category_path, process.name)
+                              category_path, location_code, process.name)
             process.category = _category(
                 category_path, olca.ModelType.PROCESS, writer, created_ids)
             process.description = _val(d, 'description')
             process.process_type = olca.ProcessType.UNIT_PROCESS
-            process.location = _location(_val(d, 'location', 'name'),
-                                         writer, created_ids)
+            process.location = _location(location_code, writer, created_ids)
             process.process_documentation = _process_doc(
                 _val(d, 'processDocumentation'), writer, created_ids)
             _process_dq(d, process)
@@ -286,11 +286,12 @@ def _process_ref(d: dict) -> Optional[olca.ProcessRef]:
     pr = olca.ProcessRef()
     pr.name = _val(d, 'name')
     category_path = _val(d, 'categoryPath')
+    location_code = _val(d, 'location', default='')
     if isinstance(category_path, list):
         category_path = '/'.join(category_path)
     pr.id = _uid(olca.ModelType.PROCESS,
-                 category_path, pr.name)
-    pr.location = _val(d, 'location', default='')
+                 category_path, location_code, pr.name)
+    pr.location = location_code
     pr.process_type = olca.ProcessType.UNIT_PROCESS
     return pr
 

--- a/electricitylci/olca_jsonld_writer.py
+++ b/electricitylci/olca_jsonld_writer.py
@@ -284,9 +284,12 @@ def _process_ref(d: dict) -> Optional[olca.ProcessRef]:
     if not isinstance(d, dict):
         return None
     pr = olca.ProcessRef()
-    pr.id = _val(d, 'id')
     pr.name = _val(d, 'name')
-    pr.category_path = _val(d, 'categoryPath')
+    category_path = _val(d, 'categoryPath')
+    if isinstance(category_path, list):
+        category_path = '/'.join(category_path)
+    pr.id = _uid(olca.ModelType.PROCESS,
+                 category_path, pr.name)
     pr.location = _val(d, 'location', default='')
     pr.process_type = olca.ProcessType.UNIT_PROCESS
     return pr

--- a/electricitylci/olca_jsonld_writer.py
+++ b/electricitylci/olca_jsonld_writer.py
@@ -94,7 +94,7 @@ def _exchange(d: dict, writer: pack.Writer,
     e.flow = _flow(_val(d, 'flow'), flowprop, writer, created_ids)
     e.dq_entry = _format_dq_entry(_val(d, 'dqEntry'))
     e.uncertainty = _uncertainty(_val(d, 'uncertainty'))
-    e.provider = _process_ref(_val(d, 'provider'))
+    e.default_provider = _process_ref(_val(d, 'provider'))
     e.description = _val(d, 'comment')
     return e
 

--- a/electricitylci/olca_jsonld_writer.py
+++ b/electricitylci/olca_jsonld_writer.py
@@ -77,6 +77,7 @@ def _category(path: str, mtype: olca.ModelType, writer: pack.Writer,
         parent.category_path = uid_path[1:]
     return parent
 
+
 def _exchange(d: dict, writer: pack.Writer,
               created_ids: set) -> Optional[olca.Exchange]:
     if d is None:
@@ -93,8 +94,8 @@ def _exchange(d: dict, writer: pack.Writer,
     e.flow = _flow(_val(d, 'flow'), flowprop, writer, created_ids)
     e.dq_entry = _format_dq_entry(_val(d, 'dqEntry'))
     e.uncertainty = _uncertainty(_val(d, 'uncertainty'))
-    e.provider = _processRef(_val(d, 'provider'))
-    e.comment = _val(d,'comment')
+    e.provider = _process_ref(_val(d, 'provider'))
+    e.description = _val(d, 'comment')
     return e
 
 
@@ -278,15 +279,18 @@ def _uncertainty(d: dict) -> Optional[olca.Uncertainty]:
     u.geom_sd = gsd
     return u
 
-def _processRef(d: dict) -> Optional[olca.ProcessRef]:
+
+def _process_ref(d: dict) -> Optional[olca.ProcessRef]:
     if not isinstance(d, dict):
         return None
     pr = olca.ProcessRef()
-    pr.name = _val(d,'name')
-    pr.category_path = d['categoryPath']
-    pr.location = _val(d,'location',default='')
+    pr.id = _val(d, 'id')
+    pr.name = _val(d, 'name')
+    pr.category_path = _val(d, 'categoryPath')
+    pr.location = _val(d, 'location', default='')
     pr.process_type = olca.ProcessType.UNIT_PROCESS
     return pr
+
 
 def _isnum(n) -> bool:
     if not isinstance(n, (float, int)):
@@ -327,4 +331,3 @@ def _format_date(entry: str) -> Optional[str]:
 def _uid(*args):
     path = '/'.join([str(arg).strip() for arg in args]).lower()
     return str(uuid.uuid3(uuid.NAMESPACE_OID, path))
-


### PR DESCRIPTION
There was an error in the olca-schema description: the `comment` field in the Exchange type should be named `description` and the field `provider` should be `defaultProvider` (this is what openLCA uses in the import and export). I corrected that in the olca-schema and olca-ipc package (you need to update it via `pip install –U olca-ipc`). 