### PR TITLE
Optional define modelname w stdin

### DIFF
--- a/electricitylci/__init__.py
+++ b/electricitylci/__init__.py
@@ -1,3 +1,4 @@
+from electricitylci.model_config import model_name
 
 def get_generation_process_df(source='egrid', regions='all'):
     """Create a dataframe of inputs and outputs to electricity generation processes."""
@@ -41,7 +42,6 @@ def write_distribution_dict():
 def write_process_dicts_to_jsonld(*process_dicts):
     from electricitylci.olca_jsonld_writer import write
     from electricitylci.globals import output_dir
-    from electricitylci.model_config import model_name
     all_process_dicts = dict()
     for d in process_dicts:
         all_process_dicts={**all_process_dicts,**d}

--- a/electricitylci/globals.py
+++ b/electricitylci/globals.py
@@ -1,5 +1,7 @@
 import os
 
+set_model_name_with_stdin = True
+
 def set_dir(directory):
     if not os.path.exists(directory): os.makedirs(directory)
     return directory
@@ -23,3 +25,15 @@ def join_with_underscore(items):
 
 electricity_flow_name_generation_and_distribution = 'Electricity, AC, 2300-7650 V'  #ref Table 1.1 NERC report
 electricity_flow_name_consumption = 'Electricity, AC, 120 V'
+
+def list_model_names_in_config():
+    configdir = modulepath + 'modelconfig/'
+    configfiles = os.listdir(configdir)
+    modelnames_dict = {}
+    selection_num = 1
+    for f in configfiles:
+        f = f.strip('_config.json')
+        modelnames_dict[selection_num]=f
+        selection_num+=1
+    return modelnames_dict
+

--- a/electricitylci/model_config.py
+++ b/electricitylci/model_config.py
@@ -1,11 +1,30 @@
 import json
 import pandas as pd
 
-from electricitylci.globals import modulepath, data_dir
+from electricitylci.globals import modulepath, data_dir, set_model_name_with_stdin, list_model_names_in_config
 
 #################
-#Set model_name here
-model_name = 'ELCI_1'
+model_name_exists = False
+try:
+    model_name
+    model_name_exists = True
+except NameError:
+    model_name_exists = False
+
+if set_model_name_with_stdin and not model_name_exists:
+    model_menu = list_model_names_in_config()
+    print("Select a model number to use:")
+    for k in model_menu.keys():
+        print("\t"+str(k)+": "+model_menu[k])
+    model_num = input()
+    try:
+        model_name = model_menu[int(model_num)]
+        print("Model " + model_name + " selected.")
+    except:
+        print('You must select the menu number for an existing model')
+elif not set_model_name_with_stdin:
+    # Set model_name manually here
+    model_name = 'ELCI_3'
 #################
 
 #pull in model config vars


### PR DESCRIPTION
electricitylci still required a user to manually edit the model_config.py file if they wanted to change models to use. I finally figured a way to get around this using standard input to request the user select a model from a menu.

This can be turned on and off in globals but will be on by default. Turning it off will be more convenient for development and testing with a model_name still manually set in model_config.  

