### PR TITLE
Issues/75

### DIFF
--- a/electricitylci/__init__.py
+++ b/electricitylci/__init__.py
@@ -142,8 +142,14 @@ def get_generation_mix_process_df(regions=None):
     if regions is None:
         regions = model_specs['regional_aggregation']
 
-    if replace_egrid:
+    if replace_egrid or regions in ["BA","FERC"]:
         # assert regions == 'BA' or regions == 'NERC', 'Regions must be BA or NERC'
+        if regions in ["BA","FERC"] and not replace_egrid:
+            logger.info(
+                f"Actual generation data is being used for the generation mix "
+                f"despite replace_egrid = False. The reference eGrid electricity "
+                f"data cannot be reorgnznied to match BA or FERC regions"
+                )
         print("Actual generation data is used when replacing eGRID")
         generation_data = build_generation_data(
             generation_years=[eia_gen_year]

--- a/electricitylci/__init__.py
+++ b/electricitylci/__init__.py
@@ -142,13 +142,15 @@ def get_generation_mix_process_df(regions=None):
     if regions is None:
         regions = model_specs['regional_aggregation']
 
-    if replace_egrid or regions in ["BA","FERC"]:
+    if replace_egrid or regions in ["BA","FERC","US"]:
         # assert regions == 'BA' or regions == 'NERC', 'Regions must be BA or NERC'
-        if regions in ["BA","FERC"] and not replace_egrid:
+        if regions in ["BA","FERC","US"] and not replace_egrid:
             logger.info(
                 f"Actual generation data is being used for the generation mix "
                 f"despite replace_egrid = False. The reference eGrid electricity "
-                f"data cannot be reorgnznied to match BA or FERC regions"
+                f"data cannot be reorgnznied to match BA or FERC regions. For "
+                f"the US region, the function for generating US mixes does not "
+                f"support aggregating to the US."
                 )
         print("Actual generation data is used when replacing eGRID")
         generation_data = build_generation_data(

--- a/electricitylci/generation_mix.py
+++ b/electricitylci/generation_mix.py
@@ -101,6 +101,7 @@ def create_generation_mix_process_df_from_model_generation_data(
         #     database_for_genmix_final['Balancing Authority Name']
         # )
     else:
+        egrid_facilities_w_fuel_region["FacilityID"]=egrid_facilities_w_fuel_region["FacilityID"].astype(int)
         database_for_genmix_final = pd.merge(
             generation_data, egrid_facilities_w_fuel_region, on="FacilityID"
         )

--- a/electricitylci/generation_mix.py
+++ b/electricitylci/generation_mix.py
@@ -237,17 +237,20 @@ def create_generation_mix_process_df_from_model_generation_data(
 # Only possible for a subregion, NERC region, or total US
 def create_generation_mix_process_df_from_egrid_ref_data(subregion=None):
     """
-    [summary]
+    Creates fuel generation mix by subregion using egrid reference data.
 
     Parameters
     ----------
-    subregion : [type]
+    generation_data : DataFrame
         [description]
+    subregion : str
+        Description of single region or group of regions. 
 
     Returns
     -------
-    [type]
-        [description]
+    DataFrame
+        Dataframe contains the fraction of various generation technologies
+        to produce 1 MWh of electricity.
     """
     if subregion is None:
         subregion = regional_aggregation


### PR DESCRIPTION
Small change to prevent a bug where generation mixes aren't created if replace_egrid is False and the selected aggregation region is BA, FERC, or US. For the BA and FERC regions, the reference eGrid data doesn't include BA or FERC names. The routine that uses reference eGrid data doesn't support US aggregation. The fix just re-directs to using the generation_df itself.