### PR TITLE
Fix for issue 162

### DIFF
--- a/electricitylci/generation.py
+++ b/electricitylci/generation.py
@@ -116,7 +116,7 @@ def aggregate_facility_flows(df):
         "Electricity",
         "FlowName",
         "Source",
-        "Compartment_path",
+        "Compartment",
         "stage_code"
     ]
 


### PR DESCRIPTION
Coal inventory emissions come in with Compartment_path=NaN, so emissions with the same name from different compartments (e.g., ammonia to air, ammonia to water, ammonia to ground) were getting dropped to just 1 compartment at the duplication check,