### PR TITLE
Issues/175

### DIFF
--- a/electricitylci/__init__.py
+++ b/electricitylci/__init__.py
@@ -125,12 +125,9 @@ def get_generation_mix_process_df(regions=None):
         90       AKGD        HYDRO  5.477350e+05  ASCC          0.114605
         114      AKGD      BIOMASS  5.616577e+04  ASCC          0.011752
     """
-    from electricitylci.egrid_filter import (
-        electricity_for_selected_egrid_facilities,
-    )
+
     from electricitylci.generation_mix import (
         create_generation_mix_process_df_from_model_generation_data,
-        create_generation_mix_process_df_from_egrid_ref_data,
     )
     from electricitylci.eia923_generation import build_generation_data
     
@@ -155,6 +152,12 @@ def get_generation_mix_process_df(regions=None):
             generation_data, regions
         )
     else:
+        from electricitylci.egrid_filter import (
+            electricity_for_selected_egrid_facilities,
+        )
+        from electricitylci.generation_mix import (
+            create_generation_mix_process_df_from_egrid_ref_data,
+        )
         if config.model_specs.gen_mix_from_model_generation_data:
             generation_mix_process_df = create_generation_mix_process_df_from_model_generation_data(
                 electricity_for_selected_egrid_facilities, regions

--- a/electricitylci/cems_data.py
+++ b/electricitylci/cems_data.py
@@ -24,7 +24,7 @@ from electricitylci.globals import data_dir, output_dir
 import logging
 
 data_years = {
-    'epacems': tuple(range(1995, 2019)),
+    'epacems': tuple(range(1995, 2021)),
 }
 
 epacems_columns_to_ignore = {

--- a/electricitylci/combinator.py
+++ b/electricitylci/combinator.py
@@ -449,6 +449,7 @@ def add_fuel_inputs(gen_df, upstream_df, upstream_dict):
         "NERC",
         "Subregion",
     ]
+    merge_cols = [x for x in merge_cols if x in fuel_df.columns]
     fuel_df.drop(columns=merge_cols, inplace=True)
     gen_df_reduced = gen_df[merge_cols + ["eGRID_ID"]].drop_duplicates(
         subset=["eGRID_ID"]

--- a/electricitylci/combinator.py
+++ b/electricitylci/combinator.py
@@ -332,9 +332,9 @@ def concat_clean_upstream_and_plant(pl_df, up_df):
         "Balancing Authority Name",
         "Subregion",
     ]
-
+    existing_region_cols=[x for x in pl_df.columns if x in region_cols]
     up_df = up_df.drop(columns=["eGRID_ID"], errors="ignore").merge(
-        right=pl_df[["eGRID_ID"] + region_cols].drop_duplicates(),
+        right=pl_df[["eGRID_ID"] + existing_region_cols].drop_duplicates(),
         left_on="plant_id",
         right_on="eGRID_ID",
         how="left",

--- a/electricitylci/egrid_emissions_and_waste_by_facility.py
+++ b/electricitylci/egrid_emissions_and_waste_by_facility.py
@@ -5,9 +5,24 @@ from electricitylci.model_config import model_specs
 emissions_and_wastes_by_facility = None
 if model_specs.stewicombo_file is not None:
     emissions_and_wastes_by_facility = stewicombo.getInventory(model_specs.stewicombo_file)
-
+    if "eGRID_ID" in emissions_and_wastes_by_facility.columns:
+        base_inventory = "eGRID"
+    elif "NEI_ID" in model_specs.inventories_of_interest.keys():
+        base_inventory = "NEI"
+    elif "TRI" in model_specs.inventories_of_interest.keys():
+        base_inventory = "TRI"
+    elif "RCRAInfo" in model_specs.inventories_of_interest.keys():
+        base_inventory = "RCRAInfo"
 if emissions_and_wastes_by_facility is None:
-    emissions_and_wastes_by_facility = stewicombo.combineInventoriesforFacilitiesinBaseInventory("eGRID", model_specs.inventories_of_interest, filter_for_LCI=True)
+    if "eGRID" in model_specs.inventories_of_interest.keys():
+        base_inventory = "eGRID"
+    elif "NEI" in model_specs.inventories_of_interest.keys():
+        base_inventory = "NEI"
+    elif "TRI" in model_specs.inventories_of_interest.keys():
+        base_inventory = "TRI"
+    elif "RCRAInfo" in model_specs.inventories_of_interest.keys():
+        base_inventory = "RCRAInfo"
+    emissions_and_wastes_by_facility = stewicombo.combineInventoriesforFacilitiesinBaseInventory(base_inventory, model_specs.inventories_of_interest, filter_for_LCI=True)
     # drop SRS fields
     emissions_and_wastes_by_facility = emissions_and_wastes_by_facility.drop(columns=['SRS_ID', 'SRS_CAS'])
     # drop 'Electricity' flow

--- a/electricitylci/eia_trans_dist_grid_loss.py
+++ b/electricitylci/eia_trans_dist_grid_loss.py
@@ -9,7 +9,7 @@ from electricitylci.globals import output_dir, data_dir
 import logging
 from xlrd import XLRDError
 from functools import lru_cache
-
+from zipfile import BadZipFile
 # %%
 # Set working directory, files downloaded from EIA will be saved to this location
 # os.chdir = 'N:/eLCI/Transmission and Distribution'
@@ -117,8 +117,9 @@ def eia_trans_dist_download_extract(year):
                     sheet_name="10. Source-Disposition",
                     header=3,
                     index_col=0,
+                    engine="openpyxl"
                 )
-            except XLRDError:
+            except (XLRDError, BadZipFile):
                 # The most current year has a different url - no "archive/year"
                 url = (
                     "https://www.eia.gov/electricity/state/"
@@ -132,6 +133,7 @@ def eia_trans_dist_download_extract(year):
                     sheet_name="10. Source-Disposition",
                     header=3,
                     index_col=0,
+                    engine="openpyxl"
                 )
         else:
             logging.info(
@@ -142,6 +144,7 @@ def eia_trans_dist_download_extract(year):
                 sheet_name="10. Source-Disposition",
                 header=3,
                 index_col=0,
+                engine="openpyxl"
             )
 
         df.columns = df.columns.str.replace("Year\n", "")

--- a/electricitylci/generation.py
+++ b/electricitylci/generation.py
@@ -1125,7 +1125,7 @@ def olcaschema_genprocess(database, upstream_dict={}, subregion="BA"):
             + ")"
         )
         data["pedigreeUncertainty"] = ""
-        data["comment"] = data["source_string"].str.replace("_",",") + data["Year"].astype(str)#f"{datasources} - {year}"
+        data["comment"] = data["source_string"].str.replace("_",",") + ", " + data["Year"].astype(str)#f"{datasources} - {year}"
         data_for_dict = data[cols_for_exchange_dict]
         data_for_dict = data_for_dict.append(
             ref_exchange_creator(), ignore_index=True

--- a/electricitylci/generation.py
+++ b/electricitylci/generation.py
@@ -1125,7 +1125,7 @@ def olcaschema_genprocess(database, upstream_dict={}, subregion="BA"):
             + ")"
         )
         data["pedigreeUncertainty"] = ""
-        data["comment"] = f"{datasources} - {year}"
+        data["comment"] = data["source_string"].str.replace("_",",") + data["Year"].astype(str)#f"{datasources} - {year}"
         data_for_dict = data[cols_for_exchange_dict]
         data_for_dict = data_for_dict.append(
             ref_exchange_creator(), ignore_index=True

--- a/electricitylci/generation.py
+++ b/electricitylci/generation.py
@@ -495,7 +495,7 @@ def create_generation_process_df():
         except FileNotFoundError:
             module_logger.info("Will need to load EIA860 to FRS matches using stewi facility matcher - it may take a while to download and read the required data")
             import facilitymatcher.globals as fmglob
-            from utils import set_dir
+            from electricitylci.utils import set_dir
             file = fmglob.FRS_config['FRS_bridge_file']
             file_path = fmglob.FRSpath + '/' + file
             col_dict = {'REGISTRY_ID': "str",

--- a/electricitylci/generation.py
+++ b/electricitylci/generation.py
@@ -16,14 +16,13 @@ from scipy.stats import t, norm
 from scipy.special import erfinv
 import ast
 import logging
-from electricitylci.egrid_facilities import egrid_facilities
 from electricitylci.eia923_generation import eia923_primary_fuel
 from electricitylci.eia860_facilities import eia860_balancing_authority
 from electricitylci.model_config import model_specs
 
 
 
-egrid_facilities_w_fuel_region = egrid_facilities[['FacilityID','Subregion','PrimaryFuel','FuelCategory','NERC','PercentGenerationfromDesignatedFuelCategory','Balancing Authority Name','Balancing Authority Code']]
+
 
 module_logger = logging.getLogger("generation.py")
 
@@ -450,20 +449,14 @@ def create_generation_process_df():
         build_generation_data,
         eia923_primary_fuel
     )
-    from electricitylci.egrid_filter import (
-        egrid_facilities_to_include,
-        emissions_and_waste_for_selected_egrid_facilities,
-    )
-    from electricitylci.generation import (
-        egrid_facilities_w_fuel_region,
-        add_technological_correlation_score,
-        add_temporal_correlation_score,
-    )
     import electricitylci.emissions_other_sources as em_other
     import electricitylci.ampd_plant_emissions as ampd
     from electricitylci.combinator import ba_codes
     import electricitylci.manual_edits as edits
-
+    from electricitylci.generation import (
+            add_technological_correlation_score,
+            add_temporal_correlation_score,
+        )
     COMPARTMENT_DICT = {
         "emission/air": "air",
         "emission/water": "water",
@@ -477,12 +470,62 @@ def create_generation_process_df():
     }
     if model_specs.replace_egrid:
         generation_data = build_generation_data().drop_duplicates()
+        from electricitylci.egrid_emissions_and_waste_by_facility import (
+            emissions_and_wastes_by_facility,
+            base_inventory,
+        ) 
+        eia_facilities_to_include=generation_data["FacilityID"].unique()
+        if base_inventory == "eGRID":
+            id_column="eGRID_ID"
+        elif "NEI" in model_specs.inventories_of_interest.keys():
+            id_column = "NEI_ID"
+        elif "TRI" in model_specs.inventories_of_interest.keys():
+            id_column = "TRI_ID"
+        elif "RCRAInfo" in model_specs.inventories_of_interest.keys():
+            id_column = "RCRAInfo_ID"
+        #Other columns in the emissions_and_wastes_by_Facility
+        #FacilityID and FRS_ID (in addition to those above)
+        import facilitymatcher.globals as fmglob
+        file = fmglob.FRS_config['FRS_bridge_file']
+        file_path = fmglob.FRSpath + '/' + file
+        col_dict = {'REGISTRY_ID': "str",
+            'PGM_SYS_ACRNM': "str",
+            'PGM_SYS_ID': "str"}
+        FRS_bridge = fmglob.read_FRS_file(file, col_dict)
+        eia860_FRS = fmglob.filter_by_program_list(df=FRS_bridge,program_list=["EIA-860"])
+        emissions_and_wastes_by_facility=pd.merge(
+            left=emissions_and_wastes_by_facility,
+            right=eia860_FRS,
+            left_on="FRS_ID",
+            right_on="REGISTRY_ID",
+            how="left",
+        )
+        emissions_and_wastes_by_facility.dropna(subset=["PGM_SYS_ID"],inplace=True)
+        emissions_and_wastes_by_facility.drop(columns=["NEI_ID","FRS_ID","TRI_ID","RCRAInfo_ID","PGM_SYS_ACRNM","REGISTRY_ID"],errors="ignore",inplace=True)
+        emissions_and_wastes_by_facility["FacilityID"]=emissions_and_wastes_by_facility["PGM_SYS_ID"].astype(int)
+        emissions_and_waste_for_selected_eia_facilities = emissions_and_wastes_by_facility[emissions_and_wastes_by_facility["FacilityID"].isin(eia_facilities_to_include)]
+        emissions_and_waste_for_selected_eia_facilities.rename(columns={"FacilityID":"eGRID_ID"},inplace=True)
         cems_df = ampd.generate_plant_emissions(model_specs.eia_gen_year)
         emissions_df = em_other.integrate_replace_emissions(
-            cems_df, emissions_and_waste_for_selected_egrid_facilities
+            cems_df, emissions_and_waste_for_selected_eia_facilities
         )
+        emissions_df.rename(columns={"FacilityID":"eGRID_ID"},inplace=True)
+        facilities_w_fuel_region=eia_facility_fuel_region(model_specs.eia_gen_year)
+        facilities_w_fuel_region.rename(columns={'FacilityID':'eGRID_ID'}, inplace=True)
     else:
+        from electricitylci.egrid_filter import (
+            egrid_facilities_to_include,
+            emissions_and_waste_for_selected_egrid_facilities,
+        )
+        from electricitylci.generation import (
+            egrid_facilities_w_fuel_region,
+        )
         from electricitylci.egrid_filter import electricity_for_selected_egrid_facilities
+        from electricitylci.egrid_facilities import egrid_facilities
+        facilities_w_fuel_region = egrid_facilities[['FacilityID','Subregion','PrimaryFuel','FuelCategory','NERC','PercentGenerationfromDesignatedFuelCategory','Balancing Authority Name','Balancing Authority Code']]
+        facilities_w_fuel_region["FacilityID"] = \
+            egrid_facilities_w_fuel_region["FacilityID"].astype(int)
+        facilities_w_fuel_region.rename(columns={'FacilityID':'eGRID_ID'}, inplace=True)
         generation_data=electricity_for_selected_egrid_facilities
         generation_data["Year"]=model_specs.egrid_year
         generation_data["FacilityID"]=generation_data["FacilityID"].astype(int)
@@ -490,7 +533,7 @@ def create_generation_process_df():
 #        generation_data = build_generation_data(
 #            egrid_facilities_to_include=egrid_facilities_to_include
 #        )
-    emissions_df["eGRID_ID"] = emissions_df["eGRID_ID"].astype(int)
+        emissions_df["eGRID_ID"] = emissions_df["eGRID_ID"].astype(int)
     generation_data.rename(columns={'FacilityID':'eGRID_ID'}, inplace=True)
     final_database = pd.merge(
         left=emissions_df,
@@ -498,12 +541,10 @@ def create_generation_process_df():
         on=["eGRID_ID", "Year"],
         how="left",
     )
-    egrid_facilities_w_fuel_region["FacilityID"] = \
-        egrid_facilities_w_fuel_region["FacilityID"].astype(int)
-    egrid_facilities_w_fuel_region.rename(columns={'FacilityID':'eGRID_ID'}, inplace=True)
+
     final_database = pd.merge(
         left=final_database,
-        right=egrid_facilities_w_fuel_region,
+        right=facilities_w_fuel_region,
         on="eGRID_ID",
         how="left",
         suffixes=["", "_right"],

--- a/electricitylci/generation_mix.py
+++ b/electricitylci/generation_mix.py
@@ -7,45 +7,46 @@ import numpy as np
 import pandas as pd
 from electricitylci.globals import data_dir
 from electricitylci.process_dictionary_writer import *
-from electricitylci.egrid_facilities import egrid_facilities, egrid_subregions
 from electricitylci.model_config import model_specs
 from electricitylci.generation import eia_facility_fuel_region
 import logging
 
 # Get a subset of the egrid_facilities dataset
-egrid_facilities_w_fuel_region = egrid_facilities[
-    [
-        "FacilityID",
-        "Subregion",
-        "PrimaryFuel",
-        "FuelCategory",
-        "NERC",
-        "PercentGenerationfromDesignatedFuelCategory",
-        "Balancing Authority Name",
-        "Balancing Authority Code",
+if not model_specs.replace_egrid:
+    from electricitylci.egrid_facilities import egrid_facilities, egrid_subregions
+    egrid_facilities_w_fuel_region = egrid_facilities[
+        [
+            "FacilityID",
+            "Subregion",
+            "PrimaryFuel",
+            "FuelCategory",
+            "NERC",
+            "PercentGenerationfromDesignatedFuelCategory",
+            "Balancing Authority Name",
+            "Balancing Authority Code",
+        ]
     ]
-]
 
-# Get reference regional generation data by fuel type, add in NERC
-from electricitylci.egrid_energy import (
-    ref_egrid_subregion_generation_by_fuelcategory,
-)
+    # Get reference regional generation data by fuel type, add in NERC
+    from electricitylci.egrid_energy import (
+        ref_egrid_subregion_generation_by_fuelcategory,
+    )
 
-egrid_subregions_NERC = egrid_facilities[["Subregion", "FuelCategory", "NERC"]]
-egrid_subregions_NERC = egrid_subregions_NERC.drop_duplicates()
-len(egrid_subregions_NERC)
-egrid_subregions_NERC = egrid_subregions_NERC[
-    egrid_subregions_NERC["NERC"].notnull()
-]
-ref_egrid_subregion_generation_by_fuelcategory_with_NERC = pd.merge(
-    ref_egrid_subregion_generation_by_fuelcategory,
-    egrid_subregions_NERC,
-    on=["Subregion", "FuelCategory"],
-)
+    egrid_subregions_NERC = egrid_facilities[["Subregion", "FuelCategory", "NERC"]]
+    egrid_subregions_NERC = egrid_subregions_NERC.drop_duplicates()
+    len(egrid_subregions_NERC)
+    egrid_subregions_NERC = egrid_subregions_NERC[
+        egrid_subregions_NERC["NERC"].notnull()
+    ]
+    ref_egrid_subregion_generation_by_fuelcategory_with_NERC = pd.merge(
+        ref_egrid_subregion_generation_by_fuelcategory,
+        egrid_subregions_NERC,
+        on=["Subregion", "FuelCategory"],
+    )
 
-ref_egrid_subregion_generation_by_fuelcategory_with_NERC = ref_egrid_subregion_generation_by_fuelcategory_with_NERC.rename(
-    columns={"Ref_Electricity_Subregion_FuelCategory": "Electricity"}
-)
+    ref_egrid_subregion_generation_by_fuelcategory_with_NERC = ref_egrid_subregion_generation_by_fuelcategory_with_NERC.rename(
+        columns={"Ref_Electricity_Subregion_FuelCategory": "Electricity"}
+    )
 
 
 def create_generation_mix_process_df_from_model_generation_data(

--- a/electricitylci/process_dictionary_writer.py
+++ b/electricitylci/process_dictionary_writer.py
@@ -16,8 +16,15 @@ from electricitylci.globals import (
     elci_version
 )
 from electricitylci.utils import make_valid_version_num
-from electricitylci.egrid_facilities import egrid_subregions,international_reg
 from electricitylci.model_config import model_specs
+if not model_specs.replace_egrid:
+    from electricitylci.egrid_facilities import egrid_subregions
+else:
+    egrid_subregions=[]
+from electricitylci.globals import data_dir
+
+international = pd.read_csv(data_dir+'/International_Electricity_Mix.csv')
+international_reg = list(pd.unique(international['Subregion']))
 
 
 module_logger = logging.getLogger("process_dictionary_writer.py")


### PR DESCRIPTION
These are mostly changes to make the electricitylci reliant on eGRID data. This is important for trying to generate inventories for more recent years, where eGRID isn't currently available. My tests so far only include removing eGRID and RCRAInfo from the inventories of interest. It would be nice to test against the various iterations for the inventories of interest but maybe unnecessary. I would appreciate the help in at least adding RCRAInfo back into the list because my computer security prevents me from getting RCRA.