### PR TITLE
Allows for sourcing stewicombo emissions data instead of regenerating

### DIFF
--- a/electricitylci/egrid_emissions_and_waste_by_facility.py
+++ b/electricitylci/egrid_emissions_and_waste_by_facility.py
@@ -11,7 +11,6 @@ import pandas as pd
 from stewicombo import getInventory
 from stewicombo import saveInventory
 from stewicombo import combineInventoriesforFacilitiesinBaseInventory as cbi
-from electricitylci.model_config import model_specs
 
 
 ##############################################################################
@@ -21,87 +20,95 @@ __doc__ = """This module populates the data frame variable,
 `emissions_and_wastes_by_facility` that contains the combined inventories for
 all facilities from all of the specified sources.
 
-This module will either use an existing inventory determined from the
-'inventories_of_interest' specified in the configuration file or create one by
-calling the `stewicombo` package from Standardized Emission and Waste
-Inventories (StEWI).
+This module will either use an existing specified combined inventory file
+specified by the 'stewicombo_file' parameter, or will create one from the
+'inventories_of_interest' specified in the configuration file by calling the
+`stewicombo` package from Standardized Emission and Waste Inventories (StEWI).
 
-If there is no existing CSV file, the call to stewicombo to generate the
-inventory can take some time. It should be noted that this module is executed
-immediately upon import (e.g., in generation.py), which may cause some
-unexpected delays if the CSV file is not present.
+If there is no existing parquet file stored in the local data directory,
+stewicombo will generate one. 
 
 Last edited:
-    2023-12-19
+    2025-02-24
 """
 __all__ = [
-    'base_inventory',
-    'emissions_and_wastes_by_facility',
+    'get_combined_stewicombo_file',
 ]
 
 
 ##############################################################################
-# GLOBALS
+# FUNCTIONS
 ##############################################################################
-emissions_and_wastes_by_facility = None
-'''pandas.DataFrame : Facility-level inventory. Defaults to none.'''
+def get_combined_stewicombo_file(model_specs):
+    """Loads, or if not available generates the combined inventory file from
+    stewicombo.
 
-base_inventory = ""
-'''str : Inventory of interest name. Defaults to empty string.'''
+    Parameters
+    ----------
+    model_specs : object of class ModelSpecs
 
-if model_specs.stewicombo_file is not None:
-    emissions_and_wastes_by_facility = getInventory(model_specs.stewicombo_file)
-    if "eGRID_ID" in emissions_and_wastes_by_facility.columns:
-        base_inventory = "eGRID"
-    elif "NEI_ID" in model_specs.inventories_of_interest.keys():
-        base_inventory = "NEI"
-    elif "TRI" in model_specs.inventories_of_interest.keys():
-        base_inventory = "TRI"
-    elif "RCRAInfo" in model_specs.inventories_of_interest.keys():
-        base_inventory = "RCRAInfo"
+    Returns
+    -------
+    df
+        The combined inventories for all facilities from all of the
+        specified sources.
+    """
+    df = None
+    '''pandas.DataFrame : Facility-level inventory. Defaults to none.'''
 
-# Define the preferred priority list of facilities to base inventories upon.
-if emissions_and_wastes_by_facility is None:
-    if "eGRID" in model_specs.inventories_of_interest.keys():
-        base_inventory = "eGRID"
-    elif "NEI" in model_specs.inventories_of_interest.keys():
-        base_inventory = "NEI"
-    elif "TRI" in model_specs.inventories_of_interest.keys():
-        base_inventory = "TRI"
-    elif "RCRAInfo" in model_specs.inventories_of_interest.keys():
-        base_inventory = "RCRAInfo"
+    if model_specs.stewicombo_file is not None:
+        df = getInventory(model_specs.stewicombo_file, download_if_missing=True)
+    else:
+        df = getInventory(model_specs.model_name)
 
-    # HOTFIX: work-around ParseError [2024-02-12; TWD]
-    # NOTE: Hi! If you are here, then you might be experiencing trouble with
-    # stewi and stewicombo data files. If this is your only project that
-    # relies on stewicombo, then delete the stewi and stewicombo data store
-    # folders on your computer (see globals.get_datastore_dir), then run
-    # try again. This will pull StEWI's pre-processed data. See GitHub issue:
-    # https://github.com/USEPA/standardizedinventories/issues/151
-    emissions_and_wastes_by_facility = cbi(
-        base_inventory,
-        model_specs.inventories_of_interest,
-        filter_for_LCI=True,
-        download_if_missing=True,
-    )
-    # Drop SRS fields
-    emissions_and_wastes_by_facility = emissions_and_wastes_by_facility.drop(
-        columns=['SRS_ID', 'SRS_CAS'])
-    # Drop 'Electricity' flow
-    emissions_and_wastes_by_facility = emissions_and_wastes_by_facility[
-        emissions_and_wastes_by_facility['FlowName'] != 'Electricity']
-    # Save stewicombo processed file
-    saveInventory(
-        model_specs.model_name,
-        emissions_and_wastes_by_facility,
-        model_specs.inventories_of_interest
-    )
+    # If the stewicombo file can't be found, generate it
+    # Define the preferred priority list of facilities to base inventories upon.
+    if df is None:
+        if "eGRID" in model_specs.inventories_of_interest.keys():
+            base_inventory = "eGRID"
+        elif "NEI" in model_specs.inventories_of_interest.keys():
+            base_inventory = "NEI"
+        elif "TRI" in model_specs.inventories_of_interest.keys():
+            base_inventory = "TRI"
+        elif "RCRAInfo" in model_specs.inventories_of_interest.keys():
+            base_inventory = "RCRAInfo"
 
+        # HOTFIX: work-around ParseError [2024-02-12; TWD]
+        # NOTE: Hi! If you are here, then you might be experiencing trouble with
+        # stewi and stewicombo data files. If this is your only project that
+        # relies on stewicombo, then delete the stewi and stewicombo data store
+        # folders on your computer (see globals.get_datastore_dir), then run
+        # try again. This will pull StEWI's pre-processed data. See GitHub issue:
+        # https://github.com/USEPA/standardizedinventories/issues/151
+        df = cbi(
+            base_inventory = base_inventory,
+            inventory_dict = model_specs.inventories_of_interest,
+            filter_for_LCI=True,
+            remove_overlap=True,
+            keep_sec_cntx=False,
+            download_if_missing=True,
+        )
+        # Drop SRS fields and Electricitiy flow
+        df = (df
+              .drop(columns=['SRS_ID', 'SRS_CAS'])
+              .query('FlowName != "Electricity"')
+              )
+        # Save stewicombo processed file for later access
+        saveInventory(
+            name = model_specs.model_name,
+            combinedinventory_df = df,
+            inventory_dict = model_specs.inventories_of_interest
+        )
+    return df
 
 ##############################################################################
 # MAIN
 ##############################################################################
 if __name__ == "__main__":
+    from electricitylci.model_config import build_model_class
+    model_config = build_model_class('ELCI_2020')
+
+    emissions_and_wastes_by_facility = get_combined_stewicombo_file(model_config)
     len(emissions_and_wastes_by_facility)
     # with egrid 2016, tri 2016, nei 2016, rcrainfo 2015: 106284
 

--- a/electricitylci/egrid_filter.py
+++ b/electricitylci/egrid_filter.py
@@ -22,7 +22,7 @@ from electricitylci.egrid_energy import (
     egrid_net_generation
 )
 from electricitylci.egrid_emissions_and_waste_by_facility import (
-    emissions_and_wastes_by_facility
+    get_combined_stewicombo_file
 )
 from electricitylci.egrid_FRS_matches import list_FRS_ids_filtered_for_NAICS
 
@@ -113,6 +113,7 @@ electricity_for_selected_egrid_facilities = egrid_net_generation[
 
 # Emissions and wastes filtering
 # Start with all emissions and wastes; these are in this file
+emissions_and_wastes_by_facility = get_combined_stewicombo_file(model_specs)
 emissions_and_waste_for_selected_egrid_facilities = emissions_and_wastes_by_facility[
      emissions_and_wastes_by_facility['eGRID_ID'].isin(
          egrid_facilities_to_include)

--- a/electricitylci/generation.py
+++ b/electricitylci/generation.py
@@ -43,7 +43,7 @@ from electricitylci.utils import make_valid_version_num
 from electricitylci.utils import check_output_dir
 from electricitylci.utils import write_csv_to_output
 from electricitylci.egrid_emissions_and_waste_by_facility import (
-    emissions_and_wastes_by_facility,
+    get_combined_stewicombo_file,
 )
 import facilitymatcher.globals as fmglob  # provided by StEWI
 
@@ -812,6 +812,7 @@ def create_generation_process_df():
         # numbers and maps them to eGRID facility numbers.
         # NOTE: there are unmatched facilities that are found in FRS_bridge,
         # but not in EIA (e.g., EGRID, RCRA).
+        emissions_and_wastes_by_facility = get_combined_stewicombo_file(model_specs)
         ewf_df = pd.merge(
             left=emissions_and_wastes_by_facility,
             right=eia860_FRS,

--- a/electricitylci/model_config.py
+++ b/electricitylci/model_config.py
@@ -173,10 +173,7 @@ class ModelSpecs:
             "include_upstream_processes"]
         self.inventories_of_interest = model_specs["inventories_of_interest"]
         self.inventories = list(model_specs["inventories_of_interest"])
-        if "stewicombo_file" in model_specs:
-            self.stewicombo_file = model_specs["stewicombo_file"]
-        else:
-            self.stewicombo_file = None
+        self.stewicombo_file = model_specs.get("stewicombo_file")
         self.include_only_egrid_facilities_with_positive_generation = model_specs["include_only_egrid_facilities_with_positive_generation"]
         self.filter_on_efficiency = model_specs['filter_on_efficiency']
         self.egrid_facility_efficiency_filters = model_specs[

--- a/electricitylci/modelconfig/ELCI_2020_config.yml
+++ b/electricitylci/modelconfig/ELCI_2020_config.yml
@@ -54,6 +54,7 @@ inventories_of_interest:
   TRI: 2020
   NEI: 2020
   RCRAInfo: 2019
+stewicombo_file: 'ELCI_2020_v1.1.4'
 
 # Provide uncertainty estimates for emissions.
 calculate_uncertainty: true

--- a/electricitylci/modelconfig/ELCI_2021_config.yml
+++ b/electricitylci/modelconfig/ELCI_2021_config.yml
@@ -54,6 +54,7 @@ inventories_of_interest:
   TRI: 2021
   NEI: 2020
   RCRAInfo: 2021
+stewicombo_file: 'ELCI_2021_v1.1.4'
 
 # Provide uncertainty estimates for emissions.
 calculate_uncertainty: true

--- a/electricitylci/modelconfig/ELCI_2022_config.yml
+++ b/electricitylci/modelconfig/ELCI_2022_config.yml
@@ -54,6 +54,7 @@ inventories_of_interest:
   TRI: 2021
   NEI: 2020
   RCRAInfo: 2021
+stewicombo_file: 'ELCI_2022_v1.1.4'
 
 # Provide uncertainty estimates for emissions.
 calculate_uncertainty: true


### PR DESCRIPTION
Maintains consistency across users; resolves #292 

Also avoids the need to hold this df in memory.